### PR TITLE
Bump accepted EULA version

### DIFF
--- a/spider.config
+++ b/spider.config
@@ -1,2 +1,2 @@
 storage.db_dir=
-eula.accepted=8
+eula.accepted=11


### PR DESCRIPTION
Screaming frog won't run without having accepted the latest EULA version. This bumps the accepted EULA version up to version 11.